### PR TITLE
Fix API URL generation in pages

### DIFF
--- a/Pages/SpodOrderSubs.cshtml.cs
+++ b/Pages/SpodOrderSubs.cshtml.cs
@@ -16,7 +16,8 @@ public class SpodOrderSubsModel : PageModel
     public async Task OnGetAsync(string PaperNum)
     {
         this.PaperNum = PaperNum;
-        var url = $"http://localhost:5290/api/SpodOrderSubs?PaperNum={PaperNum}";
+        var baseUrl = $"{Request.Scheme}://{Request.Host}";
+        var url = $"{baseUrl}/api/SpodOrderSubs?PaperNum={PaperNum}";
         OrderSubs = await _httpClient.GetFromJsonAsync<List<SpodOrderSub>>(url) ?? new();
     }
 }

--- a/Pages/SpodOrders.cshtml.cs
+++ b/Pages/SpodOrders.cshtml.cs
@@ -21,7 +21,8 @@ public class SpodOrdersModel : PageModel
     public async Task OnGetAsync([FromQuery(Name = "page")] int? page)
     {
         PageNumber = page ?? 1;
-        var apiUrl = $"http://localhost:5290/api/SPOdOrderMains/paged?page={PageNumber}&pageSize={PageSize}";
+        var baseUrl = $"{Request.Scheme}://{Request.Host}";
+        var apiUrl = $"{baseUrl}/api/SPOdOrderMains/paged?page={PageNumber}&pageSize={PageSize}";
         var resp = await _httpClient.GetFromJsonAsync<ApiResult>(apiUrl);
         Orders = resp?.data ?? new List<SpodOrderMain>();
         TotalCount = resp?.totalCount ?? 0;


### PR DESCRIPTION
## Summary
- avoid hardcoding API URLs in pages
- build base URL from the incoming request

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dff196b7c8322a1756bfb81564edc